### PR TITLE
Fix health check VectorSearchEngine stats access

### DIFF
--- a/src/refimage/api.py
+++ b/src/refimage/api.py
@@ -1061,11 +1061,12 @@ def create_app(settings: Optional[Settings] = None) -> FastAPI:
                 "database_path": str(storage.db_path),
             }
 
+            search_stats = search_engine.get_stats()
             search_status = {
-                "total_embeddings": search_engine.count(),
-                "embedding_dimension": search_engine.dimension,
-                "index_type": search_engine.index_type,
-                "is_trained": search_engine.is_trained,
+                "total_embeddings": search_stats["total_embeddings"],
+                "embedding_dimension": search_stats["embedding_dimension"],
+                "index_type": search_stats["index_type"],
+                "is_trained": search_stats["is_trained"],
             }
 
             return HealthResponse(


### PR DESCRIPTION
## Problem
The health check endpoint was failing with a 500 error due to AttributeError when trying to access non-existent properties on VectorSearchEngine.

## Root Cause
The health check code was attempting to access:
- `search_engine.count()`
- `search_engine.dimension`
- `search_engine.index_type`
- `search_engine.is_trained`

However, the VectorSearchEngine class only provides a `get_stats()` method that returns these values in a dictionary.

## Solution
- Replace direct property access with `get_stats()` method call
- Extract the required statistics from the returned dictionary
- Maintain the same response structure for API compatibility

## Testing
- ✅ Health check endpoint now returns 200 OK
- ✅ All required statistics are properly included in response
- ✅ No breaking changes to API response format

## Impact
- Fixes critical health check endpoint failure
- Enables proper system monitoring and status verification
- Resolves frontend connection issues caused by backend health check failures

Resolves the issue where `/health` endpoint was returning 500 errors, preventing proper system status monitoring.