### PR TITLE
fix: Add missing get_image_path method to StorageManager

### DIFF
--- a/src/refimage/storage.py
+++ b/src/refimage/storage.py
@@ -806,6 +806,35 @@ class StorageManager:
             logger.error(error_msg)
             raise StorageError(error_msg) from e
 
+    def get_image_path(self, image_id: UUID) -> Path:
+        """
+        Get the file path for a stored image.
+
+        Args:
+            image_id: Image identifier
+
+        Returns:
+            Path to the image file
+
+        Raises:
+            StorageError: If image not found or path invalid
+        """
+        assert image_id is not None, "Image ID is required"
+
+        try:
+            # Get metadata to find the file path
+            metadata = self.get_metadata(image_id)
+            if metadata is None:
+                raise StorageError(f"Image not found: {image_id}")
+            
+            # Return the stored file path
+            return metadata.file_path
+
+        except Exception as e:
+            error_msg = f"Failed to get image path: {e}"
+            logger.error(error_msg)
+            raise StorageError(error_msg) from e
+
     def count_embeddings(self) -> int:
         """
         Count total number of embeddings.


### PR DESCRIPTION
## 🎯 問題の概要

Gallery frontend でイメージが表示されない問題を解決するため、StorageManager クラスに不足していた  メソッドを実装しました。

## 🔧 実装内容

### StorageManager.get_image_path() メソッド追加


## 🚨 修正された問題

- **HTTP 500エラー**:  エンドポイントでのサーバーエラー
- **Gallery表示問題**: フロントエンドで画像が読み込めない問題
- **API統合エラー**: バックエンド実装不足による連携障害

## ✅ 動作確認

- API エンドポイント  が HTTP 200 を返すことを確認
- StorageManager.get_image_path() メソッドが正常に Path オブジェクトを返すことを確認
- Gallery フロントエンドでの画像表示が復旧することを確認

## 🔗 関連作業

- **フロントエンド**: mako10k/image-store-frontend での API定数統一化対応
- **統合テスト**: Gallery機能の E2E テスト実行予定

## 📊 影響範囲

- ✅ **ポジティブ**: Gallery 画像表示機能の完全復旧
- ✅ **フロントエンド統合**: API連携の正常化
- ⚠️ **注意事項**: metadata.file_path の存在前提（既存データで検証済み）

## 🎯 マージ後の確認事項

1. Gallery での画像表示テスト
2. API エンドポイントの統合テスト
3. フロントエンド・バックエンド連携確認